### PR TITLE
Es add reaction to post, GET and POST reactionPost operations

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -4,3 +4,4 @@ from .reaction import Reaction
 from .tag import Tag
 from .tagPost import TagPost
 from .user import User
+from .reactionPost import ReactionPost

--- a/models/reactionPost.py
+++ b/models/reactionPost.py
@@ -1,0 +1,10 @@
+class ReactionPost():
+
+    # Class initializer. 
+    # special `self` parameter that every method on a class
+    # needs as the first parameter.
+    def __init__(self, id, reaction_id, post_id, user_id):
+        self.id = id
+        self.reaction_id = reaction_id
+        self.post_id = post_id
+        self.user_id = user_id

--- a/reactionPosts/__init__.py
+++ b/reactionPosts/__init__.py
@@ -1,0 +1,1 @@
+from .request import create_reactionPost, get_reactionPosts

--- a/reactionPosts/request.py
+++ b/reactionPosts/request.py
@@ -1,0 +1,53 @@
+import sqlite3
+import json
+from models import ReactionPost
+
+
+def get_reactionPosts():
+    with sqlite3.connect("./rare.db") as conn:
+
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        # Write the SQL query to get the information you want
+        db_cursor.execute("""
+        SELECT
+           rp.id,
+           rp.reaction_id,
+           rp.post_id,
+           rp.user_id
+        FROM reactionPost rp
+        """)
+
+        # Initialize an empty list to hold all reactionPost representations
+        reactionPosts = []
+
+        # Convert rows of data into a Python list
+        dataset = db_cursor.fetchall()
+
+        # Iterate list of data returned from database
+        for row in dataset:
+
+            reactionPost = ReactionPost(row['id'], row['reaction_id'], row['post_id'], row['user_id'])
+            reactionPosts.append(reactionPost.__dict__)
+
+    # Use `json` package to properly serialize list as JSON
+    return json.dumps(reactionPosts)
+
+
+def create_reactionPost(new_reactionPost):
+    with sqlite3.connect("./rare.db") as conn:
+        db_cursor = conn.cursor()
+        db_cursor.execute("""
+        INSERT INTO ReactionPost
+            (  reaction_id, post_id, user_id )
+        VALUES
+            ( ?, ?, ?);
+        """, (new_reactionPost['reaction_id'], new_reactionPost['post_id'], new_reactionPost['user_id'] ))
+
+        id = db_cursor.lastrowid
+
+        new_reactionPost['id'] = id
+
+
+    return json.dumps(new_reactionPost)

--- a/request_handler.py
+++ b/request_handler.py
@@ -12,6 +12,7 @@ from models import Category, Post, Reaction, Tag, User
 from users import get_user_by_email, create_user, get_all_users
 from categories import get_categories
 from tags import get_tags, create_tag
+from reactionPosts import create_reactionPost, get_reactionPosts
 
 
 
@@ -102,6 +103,9 @@ class HandleRequests(BaseHTTPRequestHandler):
 
             if resource == "tagPosts" and id is None:
                 response = get_tagPosts()
+
+            if resource == "reactionPosts" and id is None:
+                response = get_reactionPosts()
      
         
         elif len(parsed) == 3:
@@ -139,6 +143,9 @@ class HandleRequests(BaseHTTPRequestHandler):
 
         if resource == "reactions":
             new_resource = create_reaction(post_body)
+
+        if resource == "reactionPosts":
+            new_resource = create_reactionPost(post_body)
 
 
         # Encode the new animal and send in response


### PR DESCRIPTION
​## Description
When the user clicks on the reaction button, a new reactionPost object is created and saved to the database
​
## How do I access this branch?
git fetch --all
git checkout es-add-reaction-to-post
​
## Motivation and Context
This enables users to add reactions to posts and see a total count of each for each post (the length of the matching reactionPost array)
​
## How Has This Been Tested?
made sure GET and POST operations worked in postman
made sure that viewing PostDetails shows the current reactions, count of reactionPosts, and clicking on the reaction button updates the count for that reaction
lots of debugging and checking the reactionPosts variable, the reaction count variable, the filter method

to get rid of our initial dummy data, update your SQL with the following:
```
DROP TABLE if EXISTS `Reaction`;
INSERT INTO `Reaction` VALUES (null, "👍", "like");
INSERT INTO `Reaction` VALUES (null, "️❤️", "love");
INSERT INTO `Reaction` VALUES (null, "👏", "celebrate");
INSERT INTO `Reaction` VALUES (null, "💡", "insightful");
INSERT INTO `Reaction` VALUES (null, "🤔", "curious");
```
​

​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
​
## Checklist:

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.